### PR TITLE
Add support for dynamic error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ export default Ember.Component.extend(ComputedValidationsMixin, {
       'user.lastName': 'Last name is a required field.'
     },
     email: {
-      emailIsEmail: 'Please enter a valid email address.'
+      // create a dynamic error message by using a function
+      emailIsEmail: function() {
+        return `${this.get('user.email')} is not a valid email address.`;
+      }
     },
     password: {
       // you can list multiple validations

--- a/addon/mixins/computed-validations.js
+++ b/addon/mixins/computed-validations.js
@@ -24,7 +24,9 @@ export default Ember.Mixin.create({
           var validationsForProperty = Object.keys(this.computedValidations[property]);
           return validationsForProperty.reduce((errorsForProperty, validationForProperty)=> {
             if (!this.get(validationForProperty)) {
-              errorsForProperty.push(this.computedValidations[property][validationForProperty]);
+              var errorMessage = this.computedValidations[property][validationForProperty];
+              var errorMessageNeedsEvaluated = typeof errorMessage === 'function';
+              errorsForProperty.push(errorMessageNeedsEvaluated ? errorMessage.call(this) : errorMessage);
             }
             return errorsForProperty;
           }, Ember.A());

--- a/tests/unit/mixins/computed-validations-test.js
+++ b/tests/unit/mixins/computed-validations-test.js
@@ -111,3 +111,25 @@ test('it can validate a property with multiple validations', function(assert) {
   assert.equal(subject.get('computedIsInvalid'), true);
   assert.deepEqual(subject.get('computedErrors.password'), ['Please enter a password.', 'The password fields must match.']);
 });
+
+test('it can get an error message from a function return value', function(assert) {
+  var ComputedValidationsObject = Ember.Object.extend(ComputedValidationsMixin, {
+    firstName: 'Bob',
+    firstNameNotTooLong: Ember.computed.gte('firstName.length', 5),
+    computedValidations: {
+      firstName: {
+        firstNameNotTooLong: function() {
+          return `A first name of '${this.get('firstName')}' is too long.`;
+        }
+      }
+    }
+  });
+  var subject = ComputedValidationsObject.create();
+  assert.deepEqual(subject.get('computedErrors.firstName'), ["A first name of 'Bob' is too long."]);
+
+  subject.set('firstName', 'Joe');
+  assert.deepEqual(subject.get('computedErrors.firstName'), ["A first name of 'Joe' is too long."]);
+
+  subject.set('firstName', 'Joseph');
+  assert.deepEqual(subject.get('computedErrors.firstName'), []);
+});


### PR DESCRIPTION
Allow for dynamic error message by specifying a function rather than a string.  `this` within the function will be the context where `ComputedValidationsMixin` is mixed into.

This fixes #2
